### PR TITLE
Changed return types of usecases

### DIFF
--- a/web/app/usecases/customer.py
+++ b/web/app/usecases/customer.py
@@ -36,7 +36,7 @@ def get_customer(conn: psycopg2.extensions.connection, customer_id: int) -> Cust
     return customer
 
 
-def create_customer(conn: psycopg2.extensions.connection, customer_info: CustomerInfo) -> int:
+def create_customer(conn: psycopg2.extensions.connection, customer_info: CustomerInfo) -> Customer:
     cur = conn.cursor()
 
     address_id = create_address(conn, customer_info.address)
@@ -58,4 +58,4 @@ def create_customer(conn: psycopg2.extensions.connection, customer_info: Custome
     if response is None:
         raise UnableToCreateCustomer()
     
-    return response[0]
+    return get_customer(conn, response[0])

--- a/web/app/usecases/supplier.py
+++ b/web/app/usecases/supplier.py
@@ -35,7 +35,7 @@ def get_supplier(conn: psycopg2.extensions.connection, supplier_id: int) -> Supp
     return supplier
 
 
-def create_supplier(conn: psycopg2.extensions.connection, supplier_info: SupplierInfo) -> int:
+def create_supplier(conn: psycopg2.extensions.connection, supplier_info: SupplierInfo) -> Supplier:
     cur = conn.cursor()
 
     address_id = create_address(conn, supplier_info.address)
@@ -56,4 +56,4 @@ def create_supplier(conn: psycopg2.extensions.connection, supplier_info: Supplie
     if supplier_id is None:
         raise UnableToCreateSupplier()
 
-    return supplier_id[0]
+    return get_supplier(conn, supplier_id[0])

--- a/web/tests/usecases/test_customer.py
+++ b/web/tests/usecases/test_customer.py
@@ -32,11 +32,18 @@ def create_customer_sample() -> CustomerInfo:
 
 
 def test_customer_creation(db_connection):
-    expected_customer = create_customer_sample()
-    customer_id = customer.create_customer(db_connection, expected_customer)
-    _customer = customer.get_customer(db_connection, customer_id)
+    expected_customer_info = create_customer_sample()
+    created_customer = customer.create_customer(db_connection, expected_customer_info)
+    
+    assert created_customer.info == expected_customer_info
 
-    assert _customer.info == expected_customer
+
+def test_customer_getable_after_creation(db_connection):
+    expected_customer_info = create_customer_sample()
+    created_customer = customer.create_customer(db_connection, expected_customer_info)
+    found_customer = customer.get_customer(db_connection, created_customer.id)
+
+    assert created_customer == found_customer
 
 
 def test_customer_not_found(db_connection):

--- a/web/tests/usecases/test_supplier.py
+++ b/web/tests/usecases/test_supplier.py
@@ -31,11 +31,18 @@ def create_supplier_sample() -> SupplierInfo:
 
 
 def test_supplier_creation(db_connection):
-    expected_supplier = create_supplier_sample()
-    supplier_id = supplier.create_supplier(db_connection, expected_supplier)
-    _supplier = supplier.get_supplier(db_connection, supplier_id)
+    expected_supplier_info = create_supplier_sample()
+    created_supplier = supplier.create_supplier(db_connection, expected_supplier_info)
 
-    assert _supplier.info == expected_supplier
+    assert created_supplier.info == expected_supplier_info
+
+
+def test_supplier_getable_after_creation(db_connection):
+    expected_supplier_info = create_supplier_sample()
+    created_supplier = supplier.create_supplier(db_connection, expected_supplier_info)
+    found_supplier = supplier.get_supplier(db_connection, created_supplier.id)
+
+    assert created_supplier == found_supplier
 
 
 def test_supplier_not_found(db_connection):


### PR DESCRIPTION
- Теперь usecase-ы `create_supplier` & `create_customer` возвращают объекты, что соответствует спецификации
- Обновил тесты для этих usecase-ов